### PR TITLE
Use common parser to handle typescript and javascript files.

### DIFF
--- a/data/expressjs/.gitignore
+++ b/data/expressjs/.gitignore
@@ -1,0 +1,2 @@
+repository
+index

--- a/data/expressjs/metadata.json
+++ b/data/expressjs/metadata.json
@@ -1,0 +1,8 @@
+{
+  "name": "expressjs/express",
+  "exampleQueries": [
+    "How do I render pages using template?",
+    "How can I authenticate users?",
+    "How do I setup an error handler?"
+  ]
+}

--- a/packages/quick-question-indexer/src/parser.ts
+++ b/packages/quick-question-indexer/src/parser.ts
@@ -30,8 +30,8 @@ const LanguageInfos: Array<LanguageInfo> = [
     minLoc: 4,
   },
   {
-    language: require("tree-sitter-typescript").typescript,
-    extensions: [".ts"],
+    language: require("tree-sitter-typescript").tsx,
+    extensions: [".js", ".jsm", ".ts", ".jsx", ".tsx"],
     nodeTypes: ["function_declaration", "class_declaration"],
     maxLevel: 1,
     minLoc: 4,

--- a/packages/quick-question-indexer/tests/data/tsx.tsx
+++ b/packages/quick-question-indexer/tests/data/tsx.tsx
@@ -1,0 +1,31 @@
+function FooComponent(props: { children: any }) { 
+  return <div>{props.children}</div>;
+}
+
+interface BarProps {
+  name: string;
+  children?: any;
+}
+
+function BarComponent(props: BarProps): any { 
+  return <FooComponent>
+    <h1 title={props.name}>
+      {props.children}
+    </h1>
+  </FooComponent>
+}
+
+class ContainerComponent {
+  props: {children: any };
+
+  constructor(props: { children: any }) {
+    this.props = props;
+  }
+  render() {
+    return (
+      <div>{this.props.children}</div>
+    );
+  }
+}
+
+export {};

--- a/packages/quick-question-indexer/tests/parser.spec.ts
+++ b/packages/quick-question-indexer/tests/parser.spec.ts
@@ -19,3 +19,12 @@ describe("parseFile: typescript", function () {
     assert.match(chunks[1].code, /class Greeter.*/);
   });
 });
+
+describe("parseFile: tsx", function () {
+  it("should success", async function () {
+    const chunks = await parseFile("./tests/data/tsx.tsx");
+    assert.equal(chunks.length, 2);
+    assert.match(chunks[0].code, /function BarComponent.*/);
+    assert.match(chunks[1].code, /class ContainerComponent.*/);
+  });
+});


### PR DESCRIPTION
Use `tsx` module of `tree-sitter-typescript` to handle all `*.js` `*.ts` `*.jsx` and `*.tsx` files. #5   
Add ExpressJS metadata for testing.