### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ git clone https://github.com/TabbyML/quick-question.git
 echo YOUR_OPENAI_API_KEY > openai_api_key.txt
 
 # Start container
-docket-compose up
+docker-compose up
 ```
 
 ## 🛠️ Development


### PR DESCRIPTION
It should be `docker-compose` instead of `docket-compose` iin the readme file.