### PR TITLE
Fix docker compose file so it works in linux distro

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     working_dir: /usr/src/app
     volumes:
       - ./data:/usr/src/app/data
-    command: /bin/bash -c 'OPENAI_API_KEY=$(cat /run/secrets/openai_api_key) yarn lerna run start --scope=quick-question'
+    command: /bin/bash -c 'OPENAI_API_KEY=$$(cat /run/secrets/openai_api_key) yarn lerna run start --scope=quick-question'
     ports:
       - 3000:3000
     secrets:


### PR DESCRIPTION
The `$` will cause docker execution failure in linux. See https://github.com/docker/compose/issues/4485
and https://docs.docker.com/compose/compose-file/#interpolation